### PR TITLE
update imports

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -14,7 +14,7 @@ import (
 	"net"
 	"net/rpc"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/shopkeep/go-rpcgen/plugin/wire"
 )
 

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -12,7 +12,7 @@ import (
 	"reflect"
 	"testing"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 type InvalidRequest struct{}

--- a/example_ae/whoami/whoami.pb.go
+++ b/example_ae/whoami/whoami.pb.go
@@ -6,7 +6,7 @@
 
 package whoami
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/examples/add/addservice/addservice.pb.go
+++ b/examples/add/addservice/addservice.pb.go
@@ -4,7 +4,7 @@
 
 package addservice
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/examples/echo/echoservice/echoservice.pb.go
+++ b/examples/echo/echoservice/echoservice.pb.go
@@ -4,7 +4,7 @@
 
 package echoservice
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/examples/remote/offload/offload.pb.go
+++ b/examples/remote/offload/offload.pb.go
@@ -4,7 +4,7 @@
 
 package offload
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/plugin/common.go
+++ b/plugin/common.go
@@ -7,8 +7,8 @@
 package plugin
 
 import (
-	descriptor "code.google.com/p/goprotobuf/protoc-gen-go/descriptor"
-	"code.google.com/p/goprotobuf/protoc-gen-go/generator"
+	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
 )
 
 // GenerateCommonStubs is the core of the plugin package.

--- a/plugin/common_test.go
+++ b/plugin/common_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"code.google.com/p/goprotobuf/proto"
-	descriptor "code.google.com/p/goprotobuf/protoc-gen-go/descriptor"
-	"code.google.com/p/goprotobuf/protoc-gen-go/generator"
+	"github.com/golang/protobuf/proto"
+	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
 )
 
 func TestGenerateCommonStubs(t *testing.T) {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"strings"
 
-	"code.google.com/p/goprotobuf/protoc-gen-go/generator"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
 )
 
 // Fail to compile if Plugin doesn't implement the generator.Plugin interface

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -7,8 +7,8 @@
 package plugin
 
 import (
-	descriptor "code.google.com/p/goprotobuf/protoc-gen-go/descriptor"
-	"code.google.com/p/goprotobuf/protoc-gen-go/generator"
+	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
 )
 
 type fakeObject string

--- a/plugin/rpc.go
+++ b/plugin/rpc.go
@@ -7,8 +7,8 @@
 package plugin
 
 import (
-	descriptor "code.google.com/p/goprotobuf/protoc-gen-go/descriptor"
-	"code.google.com/p/goprotobuf/protoc-gen-go/generator"
+	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
 )
 
 // TODO: Use io.ReadWriteCloser instead of net.Conn?

--- a/plugin/rpc_test.go
+++ b/plugin/rpc_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"code.google.com/p/goprotobuf/proto"
-	descriptor "code.google.com/p/goprotobuf/protoc-gen-go/descriptor"
-	"code.google.com/p/goprotobuf/protoc-gen-go/generator"
+	"github.com/golang/protobuf/proto"
+	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
 )
 
 func TestGenerateRPCStubs(t *testing.T) {

--- a/plugin/web.go
+++ b/plugin/web.go
@@ -7,8 +7,8 @@
 package plugin
 
 import (
-	descriptor "code.google.com/p/goprotobuf/protoc-gen-go/descriptor"
-	"code.google.com/p/goprotobuf/protoc-gen-go/generator"
+	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
 )
 
 // GenerateWebStubs generates the webrpc stubs.

--- a/plugin/web_test.go
+++ b/plugin/web_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"code.google.com/p/goprotobuf/proto"
-	descriptor "code.google.com/p/goprotobuf/protoc-gen-go/descriptor"
-	"code.google.com/p/goprotobuf/protoc-gen-go/generator"
+	"github.com/golang/protobuf/proto"
+	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
 )
 
 func TestGenerateWebStubs(t *testing.T) {

--- a/plugin/wire/wire.pb.go
+++ b/plugin/wire/wire.pb.go
@@ -4,7 +4,7 @@
 
 package wire
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/protoc-gen-go/main.go
+++ b/protoc-gen-go/main.go
@@ -1,7 +1,7 @@
 // Go support for Protocol Buffers - Google's data interchange format
 //
 // Copyright 2010 Google Inc.  All rights reserved.
-// http://code.google.com/p/goprotobuf/
+// http://github.com/golang/protobuf/
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -47,8 +47,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	"code.google.com/p/goprotobuf/proto"
-	"code.google.com/p/goprotobuf/protoc-gen-go/generator"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/generator"
 
 	_ "github.com/shopkeep/go-rpcgen/plugin"
 )

--- a/protoc-gen-go/testdata/service.pb.go
+++ b/protoc-gen-go/testdata/service.pb.go
@@ -4,7 +4,7 @@
 
 package svc
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/webrpc/proto.go
+++ b/webrpc/proto.go
@@ -13,7 +13,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 // ProtoBuf implements the Google Protocol Buffer implementation of the


### PR DESCRIPTION
Unfortunately.. I made a rookie mistake... and initially pushed to the [pguelpa fork](https://github.com/pguelpa/go-rpcgen/pull/7).. Anyway just re-quoting what I wrote there:

"Not sure if we need to change this but it looks like they have moved the original location of [Go protocol buffers](https://code.google.com/p/goprotobuf/) to [GitHub](https://github.com/golang/protobuf). So this change technically changes the imports because of that change. I came across this when trying to get protocol buffers to generate the RPC code correctly after the install."
